### PR TITLE
Changing Push Message Type to TEXT instead of VARCHAR

### DIFF
--- a/model/jpa/src/main/resources/org/jboss/aerogear/unifiedpush/api/PushMessageInformation.hbm.xml
+++ b/model/jpa/src/main/resources/org/jboss/aerogear/unifiedpush/api/PushMessageInformation.hbm.xml
@@ -11,7 +11,7 @@
             <column name="push_application_id" />
         </property>
         <property name="rawJsonMessage" type="java.lang.String">
-            <column name="raw_json_message" length="4500"/>
+            <column name="raw_json_message"/>
         </property>
         <property name="ipAddress" type="java.lang.String">
             <column name="ip_address" />


### PR DESCRIPTION
The type VARCHAR that is used in database for sending push messages is not good because it does not support unicode characters and users cannot send messages in some languages to their clients. (For example: Arabic, Persian, Urdu, etc)
The options are using NVARCHAR, TEXT and LONGTEXT.
I changed the database column type to LONGTEXT since I am sending push messages to different users that are found from my own database from multiple queries with a complicated logic.
One of my push messages contained almost 40 million characters, including more than 20k user device tokens.

I also changed hibernate settings to let the database exceed the limit of 4500 characters.

After doing the changes, it both supports unicode characters and long texts.
